### PR TITLE
Add Example Endpoint for Retrieving and Modifying Text in Dotnet-Base-Backend 

### DIFF
--- a/Dotnet_Base_Backend.API.Test/Dotnet_Base_Backend.API.Test.csproj
+++ b/Dotnet_Base_Backend.API.Test/Dotnet_Base_Backend.API.Test.csproj
@@ -12,8 +12,17 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet_Base_Backend.API\Dotnet_Base_Backend.API.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Common\Dotnet_Base_Backend.Common.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.DTO\Dotnet_Base_Backend.DTO.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Models\Dotnet_Base_Backend.Models.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Services\Dotnet_Base_Backend.Services.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dotnet_Base_Backend.API.Test/baseControllerTest.cs
+++ b/Dotnet_Base_Backend.API.Test/baseControllerTest.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Dotnet_Base_Backend.API.Controllers;
+using Dotnet_Base_Backend.Services.Interfaces;
+using Dotnet_Base_Backend.DTO;
+using Microsoft.AspNetCore.Mvc;
+using Dotnet_Base_Backend.Common.Errors;
+using FluentValidation;
+
+namespace Dotnet_Base_Backend.API.Test
+{
+    [TestClass]
+    public class BaseControllerTest
+    {
+        private Mock<IBaseService> _baseServiceMock;
+        private BaseController _baseController;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _baseServiceMock = new Mock<IBaseService>();
+            _baseController = new BaseController(_baseServiceMock.Object);
+        }
+
+        [TestMethod]
+        public async Task GetMessageTest_Valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World";
+            MessageDTO messageDTO = new MessageDTO { Message = messageExpected };
+            _baseServiceMock.Setup(x => x.GetMessage()).ReturnsAsync(new List<MessageDTO> { messageDTO });
+
+            // Act
+            var response = await _baseController.GetMessage();
+            ObjectResult result = response as ObjectResult;
+
+            List<MessageDTO> resultValue = result.Value as List<MessageDTO>;
+
+
+            // Assert
+            Assert.IsNotNull(resultValue);
+            Assert.AreEqual(messageExpected, resultValue.First().Message);
+        }
+
+        [TestMethod]
+        public async Task GetMessageTest_Invalid_exception()
+        {
+            // Arrange
+            ErrorCode errorCodeExpected = ErrorCode.INTERNAL_SERVER_ERROR;
+            _baseServiceMock.Setup(x => x.GetMessage()).ThrowsAsync(new ServicesException(errorCodeExpected));
+
+            // Act
+            var taskResult = await Assert.ThrowsExceptionAsync<ServicesException>(async () =>
+            {
+                var response = await _baseController.GetMessage();
+            });
+
+
+            // Assert
+            Assert.IsNotNull(taskResult);
+            Assert.AreEqual(errorCodeExpected, taskResult.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task SetMessage_valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World2";
+            MessageDTO messageDTO = new MessageDTO { Message = messageExpected };
+            _baseServiceMock.Setup(x => x.SetMessage(messageExpected)).ReturnsAsync(messageDTO);
+
+            // Act
+            var response = await _baseController.SetMessage(messageDTO);
+            ObjectResult result = response as ObjectResult;
+
+            MessageDTO resultValue = result.Value as MessageDTO;
+
+            // Assert
+            Assert.IsNotNull(resultValue);
+            Assert.AreEqual(messageExpected, resultValue.Message);
+        }
+
+        [TestMethod]
+        [DataRow(null, ErrorCode.REQUIRED)]
+        [DataRow("", ErrorCode.EMPTY)]
+        [DataRow("1234567890123456789012345678901234567890", ErrorCode.MAX_LENGTH)]
+        public async Task SetMessage_Invalid(string messageExpected, ErrorCode ErrorCodeExpected)
+        {
+            // Arrange
+            MessageDTO messageDTO = new MessageDTO { Message = messageExpected };
+            _baseServiceMock.Setup(x => x.SetMessage(messageExpected)).ReturnsAsync(messageDTO);
+
+            // Act
+            var taskResult = await Assert.ThrowsExceptionAsync<ValidationException>(async () =>
+            {
+                var response = await _baseController.SetMessage(messageDTO);
+            });
+            
+
+            // Assert
+            Assert.IsNotNull(taskResult);
+            Assert.AreEqual(((int) ErrorCodeExpected).ToString(), taskResult.Errors.First().ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task SearchMessage_valid()
+        {
+            // Arrange
+            string messageSearch = "Hello";
+            string messageExpected = "Hello World";
+            MessageDTO messageDTO = new MessageDTO { Message = messageExpected };
+            _baseServiceMock.Setup(x => x.SearchMessage(messageSearch)).ReturnsAsync(new List<MessageDTO> { messageDTO });
+
+            // Act
+            var response = await _baseController.SearchMessage(messageSearch);
+            ObjectResult result = response as ObjectResult;
+
+            List<MessageDTO> resultValue = result.Value as List<MessageDTO>;
+
+            // Assert
+            Assert.IsNotNull(resultValue);
+            Assert.AreEqual(messageExpected, resultValue.First().Message);
+        }
+
+        [TestMethod]
+        [DataRow(null, ErrorCode.REQUIRED)]
+        [DataRow("", ErrorCode.EMPTY)]
+        [DataRow("1234567890123456789012345678901234567890", ErrorCode.MAX_LENGTH)]
+        public async Task SearchMessage_Invalid(string messageExpected, ErrorCode ErrorCodeExpected)
+        {
+            // Arrange
+            MessageDTO messageDTO = new MessageDTO { Message = messageExpected };
+            _baseServiceMock.Setup(x => x.SetMessage(messageExpected)).ReturnsAsync(messageDTO);
+
+            // Act
+            var taskResult = await Assert.ThrowsExceptionAsync<ValidationException>(async () =>
+            {
+                var response = await _baseController.SearchMessage(messageExpected);
+            });
+
+
+            // Assert
+            Assert.IsNotNull(taskResult);
+            Assert.AreEqual(((int)ErrorCodeExpected).ToString(), taskResult.Errors.First().ErrorCode);
+        }
+    }
+}

--- a/Dotnet_Base_Backend.API/Controllers/baseController.cs
+++ b/Dotnet_Base_Backend.API/Controllers/baseController.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.DTO;
+using Dotnet_Base_Backend.Services.Interfaces;
+using Dotnet_Base_Backend.API.Validators;
+using FluentValidation;
+
+namespace Dotnet_Base_Backend.API.Controllers
+{
+    [Route("api/v1/[controller]")]
+    [ApiController]
+    public class BaseController : ControllerBase
+    {
+        private readonly IBaseService _baseService;
+
+        public BaseController(IBaseService baseService)
+        {
+            _baseService = baseService;
+        }
+
+        [HttpGet]
+        [ProducesResponseType(typeof(List<MessageDTO>),StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IList<Error>), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> GetMessage()
+        {
+            return StatusCode(StatusCodes.Status200OK, await _baseService.GetMessage());
+        }
+
+        [HttpPost]
+        [ProducesResponseType(typeof(List<MessageDTO>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IList<Error>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IList<Error>), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> SetMessage(MessageDTO message)
+        {
+            MessageDTOValidator validator = new MessageDTOValidator();
+            validator.ValidateAndThrow(message);
+
+            var res = await _baseService.SetMessage(message.Message);
+            
+            return StatusCode(StatusCodes.Status200OK, res);
+        }
+
+        [HttpGet("{message}")]
+        [ProducesResponseType(typeof(List<MessageDTO>), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(IList<Error>), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(IList<Error>), StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> SearchMessage(string message)
+        {
+            MessageDTO messageDTO = new MessageDTO { Message = message };
+            MessageDTOValidator validator = new MessageDTOValidator();
+            validator.ValidateAndThrow(messageDTO);
+
+            var res = await _baseService.SearchMessage(messageDTO.Message);
+
+            return StatusCode(StatusCodes.Status200OK, res);
+        }
+    }
+}

--- a/Dotnet_Base_Backend.API/Dotnet_Base_Backend.API.csproj
+++ b/Dotnet_Base_Backend.API/Dotnet_Base_Backend.API.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Controllers\" />
     <Folder Include="Filters\" />
-    <Folder Include="Validators\" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Dotnet_Base_Backend.Common\Dotnet_Base_Backend.Common.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.DTO\Dotnet_Base_Backend.DTO.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Services\Dotnet_Base_Backend.Services.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Dotnet_Base_Backend.API/Extensions/ValidationFailureExtension.cs
+++ b/Dotnet_Base_Backend.API/Extensions/ValidationFailureExtension.cs
@@ -7,7 +7,7 @@ namespace Dotnet_Base_Backend.API.Extensions
 {
     public static class ValidationFailureExtension
     {
-        private static readonly ResourceManager _resourceManager = new ResourceManager("Dotnet_Base_Backend.Commons.Errors.ErrorMessages", typeof(Error).Assembly);
+        private static readonly ResourceManager _resourceManager = new ResourceManager("Dotnet_Base_Backend.Common.Errors.ErrorMessages", typeof(ErrorCode).Assembly);
         public static HttpStatusCode HttpStatusCode(this FluentValidation.Results.ValidationFailure obj)
         {
             return (HttpStatusCode)(new ErrorsStatusCodes()[((ErrorCode)int.Parse(obj.ErrorCode))]);

--- a/Dotnet_Base_Backend.API/Program.cs
+++ b/Dotnet_Base_Backend.API/Program.cs
@@ -1,4 +1,8 @@
 using Dotnet_Base_Backend.API.Middleware;
+using Dotnet_Base_Backend.Repositories;
+using Dotnet_Base_Backend.Repositories.Interfaces;
+using Dotnet_Base_Backend.Services.Interfaces;
+using Dotnet_Base_Backend.Services;
 
 namespace Dotnet_Base_Backend.API
 {
@@ -15,8 +19,13 @@ namespace Dotnet_Base_Backend.API
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();
 
+
+            builder.Services.AddSingleton<IBaseRepository, BaseRepository>();
+            builder.Services.AddTransient<IBaseService, BaseService>();
+
             var app = builder.Build();
 
+            app.UseMiddleware<ErrorHandlerMiddleware>();
             // Configure the HTTP request pipeline.
             if (app.Environment.IsDevelopment())
             {
@@ -24,12 +33,10 @@ namespace Dotnet_Base_Backend.API
                 app.UseSwaggerUI();
             }
 
-            app.UseMiddleware<ErrorHandlerMiddleware>();
-
             app.UseHttpsRedirection();
-
+            app.UseRouting();
+            
             app.UseAuthorization();
-
 
             app.MapControllers();
 

--- a/Dotnet_Base_Backend.API/Validators/MessageDTOValidator.cs
+++ b/Dotnet_Base_Backend.API/Validators/MessageDTOValidator.cs
@@ -1,0 +1,18 @@
+﻿using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.DTO;
+using FluentValidation;
+using FluentValidation.Validators;
+
+namespace Dotnet_Base_Backend.API.Validators
+{
+    public class MessageDTOValidator: AbstractValidator<MessageDTO>
+    {
+        public MessageDTOValidator()
+        {
+            RuleFor(x => x.Message)
+                .NotNull().WithErrorCode(((int)ErrorCode.REQUIRED).ToString())
+                .NotEmpty().WithErrorCode(((int)ErrorCode.EMPTY).ToString())
+                .MaximumLength(20).WithErrorCode(((int)ErrorCode.MAX_LENGTH).ToString());
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Common/Dotnet_Base_Backend.Common.csproj
+++ b/Dotnet_Base_Backend.Common/Dotnet_Base_Backend.Common.csproj
@@ -15,9 +15,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Update="Errors\ErrorMessages.es.resx">
+      <CopyToOutputDirectory></CopyToOutputDirectory>
+    </EmbeddedResource>
+    <EmbeddedResource Update="Errors\ErrorMessages.fr.resx">
+      <CopyToOutputDirectory></CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Update="Errors\ErrorMessages.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>ErrorMessages.Designer.cs</LastGenOutput>
+      <CopyToOutputDirectory></CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/Dotnet_Base_Backend.Common/Errors/Error.cs
+++ b/Dotnet_Base_Backend.Common/Errors/Error.cs
@@ -16,6 +16,7 @@ namespace Dotnet_Base_Backend.Common.Errors
         public string Instance { set; get; }
         public Dictionary<string, string> AdditionalProperties { set; get; }
 
+        public Error() { }
         public Error(ErrorCode errorcode, string Message ,TypeErrors typeError,  Exception error, string Method = "", string url="")
         {             
             Status = 0;

--- a/Dotnet_Base_Backend.Common/Errors/ErrorMessages.Designer.cs
+++ b/Dotnet_Base_Backend.Common/Errors/ErrorMessages.Designer.cs
@@ -59,5 +59,50 @@ namespace Dotnet_Base_Backend.Common.Errors {
                 resourceCulture = value;
             }
         }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Message is not null.
+        /// </summary>
+        internal static string _1001 {
+            get {
+                return ResourceManager.GetString("1001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Message is not empty.
+        /// </summary>
+        internal static string _1002 {
+            get {
+                return ResourceManager.GetString("1002", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Message exceeds max length of 100 characters.
+        /// </summary>
+        internal static string _1003 {
+            get {
+                return ResourceManager.GetString("1003", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Database error.
+        /// </summary>
+        internal static string _4001 {
+            get {
+                return ResourceManager.GetString("4001", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Busca una cadena traducida similar a Internal server error.
+        /// </summary>
+        internal static string _5001 {
+            get {
+                return ResourceManager.GetString("5001", resourceCulture);
+            }
+        }
     }
 }

--- a/Dotnet_Base_Backend.Common/Errors/ErrorMessages.es.resx
+++ b/Dotnet_Base_Backend.Common/Errors/ErrorMessages.es.resx
@@ -1,101 +1,129 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="1001" xml:space="preserve">
+    <value>Mensaje es requerido</value>
+  </data>
+  <data name="1002" xml:space="preserve">
+    <value>Mensaje no debe estar vacio </value>
+  </data>
+  <data name="1003" xml:space="preserve">
+    <value>Mensaje tiene un maximo de 100 caracteres</value>
+  </data>
 </root>

--- a/Dotnet_Base_Backend.Common/Errors/ErrorMessages.fr.resx
+++ b/Dotnet_Base_Backend.Common/Errors/ErrorMessages.fr.resx
@@ -1,101 +1,129 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="1001" xml:space="preserve">
+    <value>Message requis</value>
+  </data>
+  <data name="1002" xml:space="preserve">
+    <value>Message invalid</value>
+  </data>
+  <data name="1003" xml:space="preserve">
+    <value>Message maximun 100 </value>
+  </data>
 </root>

--- a/Dotnet_Base_Backend.Common/Errors/ErrorMessages.resx
+++ b/Dotnet_Base_Backend.Common/Errors/ErrorMessages.resx
@@ -1,101 +1,135 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-	<!-- 
-		Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-		Version 1.3
-
-		The primary goals of this format is to allow a simple XML format 
-		that is mostly human readable. The generation and parsing of the 
-		various data types are done through the TypeConverter classes 
-		associated with the data types.
-
-		Example:
-
-		... ado.net/XML headers & schema ...
-		<resheader name="resmimetype">text/microsoft-resx</resheader>
-		<resheader name="version">1.3</resheader>
-		<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-		<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-		<data name="Name1">this is my long string</data>
-		<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-		<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-			[base64 mime encoded serialized .NET Framework object]
-		</data>
-		<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-			[base64 mime encoded string representing a byte array form of the .NET Framework object]
-		</data>
-
-		There are any number of "resheader" rows that contain simple 
-		name/value pairs.
-
-		Each data row contains a name, and value. The row also contains a 
-		type or mimetype. Type corresponds to a .NET class that support 
-		text/value conversion through the TypeConverter architecture. 
-		Classes that don't support this are serialized and stored with the 
-		mimetype set.
-
-		The mimetype is used for serialized objects, and tells the 
-		ResXResourceReader how to depersist the object. This is currently not 
-		extensible. For a given mimetype the value must be set accordingly:
-
-		Note - application/x-microsoft.net.object.binary.base64 is the format 
-		that the ResXResourceWriter will generate, however the reader can 
-		read any of the formats listed below.
-
-		mimetype: application/x-microsoft.net.object.binary.base64
-		value   : The object must be serialized with 
-			: System.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.soap.base64
-		value   : The object must be serialized with 
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-		mimetype: application/x-microsoft.net.object.bytearray.base64
-		value   : The object must be serialized into a byte array 
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
-	
-	<xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-		<xsd:element name="root" msdata:IsDataSet="true">
-			<xsd:complexType>
-				<xsd:choice maxOccurs="unbounded">
-					<xsd:element name="data">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-								<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
-							<xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-							<xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="resheader">
-						<xsd:complexType>
-							<xsd:sequence>
-								<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-							</xsd:sequence>
-							<xsd:attribute name="name" type="xsd:string" use="required" />
-						</xsd:complexType>
-					</xsd:element>
-				</xsd:choice>
-			</xsd:complexType>
-		</xsd:element>
-	</xsd:schema>
-	<resheader name="resmimetype">
-		<value>text/microsoft-resx</value>
-	</resheader>
-	<resheader name="version">
-		<value>1.3</value>
-	</resheader>
-	<resheader name="reader">
-		<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
-	<resheader name="writer">
-		<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-	</resheader>
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="1001" xml:space="preserve">
+    <value>Message is not null</value>
+  </data>
+  <data name="1002" xml:space="preserve">
+    <value>Message is not empty</value>
+  </data>
+  <data name="1003" xml:space="preserve">
+    <value>Message exceeds max length of 100 characters</value>
+  </data>
+  <data name="4001" xml:space="preserve">
+    <value>Database error</value>
+  </data>
+  <data name="5001" xml:space="preserve">
+    <value>Internal server error</value>
+  </data>
 </root>

--- a/Dotnet_Base_Backend.Common/Errors/RepositoryException.cs
+++ b/Dotnet_Base_Backend.Common/Errors/RepositoryException.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Resources;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -12,7 +13,7 @@ namespace Dotnet_Base_Backend.Common.Errors
     public class RepositoryException: Exception
     {
         public ErrorCode ErrorCode { get; }
-        private static readonly ResourceManager _resourceManager = new ResourceManager("Dotnet_Base_Backend.Commons.Errors.ErrorMessages", typeof(ErrorMessages).Assembly);
+        private static readonly ResourceManager _resourceManager = ErrorMessages.ResourceManager; //new ResourceManager("Dotnet_Base_Backend.Commons.Errors.ErrorMessages", typeof(ErrorMessages).Assembly);
 
         public RepositoryException(ErrorCode errorCode) : base(GetErrorMessage(errorCode))
         {

--- a/Dotnet_Base_Backend.Common/Errors/ServicesException.cs
+++ b/Dotnet_Base_Backend.Common/Errors/ServicesException.cs
@@ -12,7 +12,7 @@ namespace Dotnet_Base_Backend.Common.Errors
     public class ServicesException : Exception
     {
         public ErrorCode ErrorCode { get; }
-        private static readonly ResourceManager _resourceManager = new ResourceManager("Dotnet_Base_Backend.Commons.Errors.ErrorMessages", typeof(ErrorMessages).Assembly);
+        private static readonly ResourceManager _resourceManager = ErrorMessages.ResourceManager;
 
         public ServicesException(ErrorCode errorCode) : base(GetErrorMessage(errorCode))
         {

--- a/Dotnet_Base_Backend.DTO/MessageDTO.cs
+++ b/Dotnet_Base_Backend.DTO/MessageDTO.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.DTO
+{
+    public class MessageDTO
+    {
+        public string Message { get; set; }
+    }
+}

--- a/Dotnet_Base_Backend.DTO/NewMessageDTO.cs
+++ b/Dotnet_Base_Backend.DTO/NewMessageDTO.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.DTO
+{
+    public class NewMessageDTO
+    {
+        public string Message { get; set; }
+    }
+}

--- a/Dotnet_Base_Backend.Integration.Test/DotnetBaseBackendTest.cs
+++ b/Dotnet_Base_Backend.Integration.Test/DotnetBaseBackendTest.cs
@@ -1,0 +1,121 @@
+using Dotnet_Base_Backend.API;
+using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.DTO;
+using Dotnet_Base_Backend.Integration.Test.Utilities;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.VisualStudio.TestPlatform.CommunicationUtilities;
+using Newtonsoft.Json;
+using System.Net;
+using System.Text;
+
+namespace Dotnet_Base_Backend.Integration.Test;
+
+[TestClass]
+public class DotnetBaseBackendTest 
+{
+    private WebApplicationFactory<Program> _factory;
+    private HttpClient _client;
+
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        _factory = new WebApplicationFactory<Program>();
+        _client = _factory.CreateClient();
+    }
+
+    [TestMethod]
+    public async Task GetMessages_ReturnSuccess()
+    {
+        string messageExpected = "Hello World";
+        // Arrange
+        var response = await _client.GetAsync("/api/v1/base");
+
+        // Act
+        var responseString = await response.Content.ReadAsStringAsync();
+        var messages = JsonConvert.DeserializeObject<List<MessageDTO>>(responseString);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.IsNotNull(messages);
+        Assert.AreEqual(messageExpected, messages.First().Message);
+    }
+
+    [TestMethod]
+    public async Task SetMessage_ReturnSuccess()
+    {
+        // Arrange
+        string messageExpected = "Hello World2";
+        var message = new MessageDTO { Message = messageExpected };
+        var content = new StringContent(JsonConvert.SerializeObject(message), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/base", content);
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var messages = JsonConvert.DeserializeObject<MessageDTO>(responseString);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.IsNotNull(messages);
+        Assert.AreEqual(messageExpected, messages.Message);
+    }
+
+    [TestMethod]
+    [DataRow("",ErrorCode.EMPTY)]
+    [DataRow("0123456789012345678901234567890", ErrorCode.MAX_LENGTH)]
+    public async Task SetMessage_ReturnBadRequest(string message, ErrorCode ErrorCodeExpected)
+    {
+        // Arrange
+        var messageDTO = new MessageDTO { Message = message };
+        var content = new StringContent(JsonConvert.SerializeObject(messageDTO), Encoding.UTF8, "application/json");
+
+        // Act
+        var response = await _client.PostAsync("/api/v1/base", content);
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var Errors = JsonConvert.DeserializeObject<List<Error>>(responseString);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.IsNotNull(Errors);
+        Assert.AreEqual(ErrorCodeExpected, Errors.First().Code);
+    }
+
+    [TestMethod]
+    public async Task SearchMessage_ReturnSuccess()
+    {
+        // Arrange
+        string message = "Hello";
+        string messageExpected = "Hello World";
+        
+        // Act
+        var response = await _client.GetAsync($"/api/v1/base/{message}");
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var messages = JsonConvert.DeserializeObject<List<MessageDTO>>(responseString);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.IsNotNull(messages);
+        Assert.AreEqual(messageExpected, messages.First().Message);
+    }
+
+    [TestMethod]
+    [DataRow("0123456789012345678901234567890", ErrorCode.MAX_LENGTH)]
+    public async Task SearchMessage_ReturnBadRequest(string message, ErrorCode ErrorCodeExpected)
+    {
+        // Arrange
+
+        // Act
+        var response = await _client.GetAsync($"/api/v1/base/{message}");
+
+        var responseString = await response.Content.ReadAsStringAsync();
+        var Errors = JsonConvert.DeserializeObject<List<Error>>(responseString);
+
+        // Assert
+        Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.IsNotNull(Errors);
+        Assert.AreEqual(ErrorCodeExpected, Errors.First().Code);
+    }
+
+}

--- a/Dotnet_Base_Backend.Integration.Test/Dotnet_Base_Backend.Integration.Test.csproj
+++ b/Dotnet_Base_Backend.Integration.Test/Dotnet_Base_Backend.Integration.Test.csproj
@@ -11,15 +11,14 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Dotnet_Base_Backend.Models\Dotnet_Base_Backend.Models.csproj" />
-    <ProjectReference Include="..\Dotnet_Base_Backend.Repositories\Dotnet_Base_Backend.Repositories.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.API\Dotnet_Base_Backend.API.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dotnet_Base_Backend.Integration.Test/Utilities/CustomWebApplicationFactory.cs
+++ b/Dotnet_Base_Backend.Integration.Test/Utilities/CustomWebApplicationFactory.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Integration.Test.Utilities
+{
+    public class CustomWebApplicationFactory<TStarup>: WebApplicationFactory<TStarup>, IDisposable where TStarup : class
+    {
+        protected override void ConfigureClient(HttpClient client)
+        {
+            base.ConfigureClient(client);
+        }
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            builder.UseEnvironment("IntegrationTest");
+            builder.ConfigureServices(services =>
+            {
+                //services.AddSingleton<IBaseService, BaseService>();
+            });
+            base.ConfigureWebHost(builder);
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Models/MessagesModel.cs
+++ b/Dotnet_Base_Backend.Models/MessagesModel.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Models
+{
+    public class MessagesModel: List<string>
+    {
+        public MessagesModel()
+        {
+        }
+
+        public MessagesModel(List<string> list)
+        {
+            this.toMessagesModel(list);
+        }
+        public void toMessagesModel(List<string> list)
+        {
+            foreach (var item in list)
+            {
+                this.Add(item);
+            }
+            
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Repositories.Test/BaseRepositoryTest.cs
+++ b/Dotnet_Base_Backend.Repositories.Test/BaseRepositoryTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.Models;
+using Dotnet_Base_Backend.Repositories.Interfaces;
+using Moq;
+
+namespace Dotnet_Base_Backend.Repositories.Test
+{
+    [TestClass]
+    public class BaseRepositoryTest
+    {
+        private BaseRepository _baseRepository;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _baseRepository = new BaseRepository();
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            
+        }
+
+        [TestMethod]
+        public async Task GetMessageTest_Valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World";
+
+            // Act
+            var result = await _baseRepository.GetMessage();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(messageExpected, result.First());
+        }
+
+        [TestMethod]
+        public async Task SetMessage_valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World2";
+            var messages = new MessagesModel();
+            messages.Add(messageExpected);
+
+            // Act
+            var result = await _baseRepository.SetMessage(messageExpected);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(messageExpected, result[0]);
+        }
+
+        [TestMethod]
+        public async Task SearchMessage_valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World";
+            
+            // Act
+            var result = await _baseRepository.SearchMessage("Hello");
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(messageExpected, result.First());
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Repositories/BaseRepository.cs
+++ b/Dotnet_Base_Backend.Repositories/BaseRepository.cs
@@ -1,0 +1,56 @@
+﻿using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.Models;
+using Dotnet_Base_Backend.Repositories.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Repositories
+{
+    public class BaseRepository: IBaseRepository
+    {
+        private MessagesModel _messages = new MessagesModel();
+        public BaseRepository() 
+        {
+            _messages.Add("Hello World");
+        }
+        public async Task<MessagesModel> GetMessage()
+        {
+            try
+            {
+                return _messages;
+            }
+            catch (Exception ex)
+            {
+                throw new RepositoryException(ErrorCode.DATABASE_ERROR, ex);
+            }
+        }
+
+        public async Task<MessagesModel> SetMessage(string message)
+        {
+            try
+            {
+                _messages.Add(message);
+                return new MessagesModel() { _messages.Last() };
+            }
+            catch (Exception ex)
+            {
+                throw new RepositoryException(ErrorCode.DATABASE_ERROR, ex);
+            }
+        }
+
+        public async Task<MessagesModel> SearchMessage(string message)
+        {
+            try
+            {
+                return new MessagesModel(_messages.Where(x => x.Contains(message, StringComparison.OrdinalIgnoreCase)).ToList());
+            }
+            catch (Exception ex)
+            {
+                throw new RepositoryException(ErrorCode.DATABASE_ERROR, ex);
+            }
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Repositories/Dotnet_Base_Backend.Repositories.csproj
+++ b/Dotnet_Base_Backend.Repositories/Dotnet_Base_Backend.Repositories.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Interfaces\" />
+    <PackageReference Include="AutoMapper" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Common\Dotnet_Base_Backend.Common.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Models\Dotnet_Base_Backend.Models.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Dotnet_Base_Backend.Repositories/Interfaces/IBaseRepository.cs
+++ b/Dotnet_Base_Backend.Repositories/Interfaces/IBaseRepository.cs
@@ -1,0 +1,16 @@
+﻿using Dotnet_Base_Backend.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Repositories.Interfaces
+{
+    public interface IBaseRepository
+    {
+        Task<MessagesModel> GetMessage();
+        Task<MessagesModel> SetMessage(string message);
+        Task<MessagesModel> SearchMessage(string message);
+    }
+}

--- a/Dotnet_Base_Backend.Services.Test/BaseServicesTest.cs
+++ b/Dotnet_Base_Backend.Services.Test/BaseServicesTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Dotnet_Base_Backend.Services;
+using Dotnet_Base_Backend.Services.Interfaces;
+using Dotnet_Base_Backend.Repositories.Interfaces;
+using Dotnet_Base_Backend.Models;
+using Dotnet_Base_Backend.DTO;
+
+namespace Dotnet_Base_Backend.Services.Test
+{
+    [TestClass]
+    public class BaseServicesTest
+    {
+        private Mock<IBaseRepository> _baseRepositoryMock;
+        private IBaseService _baseService;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _baseRepositoryMock = new Mock<IBaseRepository>();
+            _baseService = new BaseService(_baseRepositoryMock.Object);
+        }
+
+        [TestMethod]
+        public async Task GetMessageTest_Valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World";
+            _baseRepositoryMock.Setup(x => x.GetMessage()).ReturnsAsync(new MessagesModel { messageExpected });
+
+            // Act
+            var result = await _baseService.GetMessage();
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(List<MessageDTO>));
+            Assert.AreEqual(messageExpected, result.First().Message);
+        }
+
+        [TestMethod]
+        public async Task SetMessage_valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World2";
+            var messages = new MessagesModel();
+            messages.Add(messageExpected);
+            _baseRepositoryMock.Setup(x => x.SetMessage(messageExpected)).ReturnsAsync(messages);
+
+            // Act
+            var result = await _baseService.SetMessage(messageExpected);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(MessageDTO));
+            Assert.AreEqual(messageExpected, result.Message);
+        }
+
+        [TestMethod]
+        public async Task SearchMessage_valid()
+        {
+            // Arrange
+            string messageExpected = "Hello World";
+            _baseRepositoryMock.Setup(x => x.SearchMessage(messageExpected)).ReturnsAsync(new MessagesModel { messageExpected });
+
+            // Act
+            var result = await _baseService.SearchMessage(messageExpected);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(List<MessageDTO>));
+            Assert.AreEqual(messageExpected, result.First().Message);
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Services.Test/Dotnet_Base_Backend.Services.Test.csproj
+++ b/Dotnet_Base_Backend.Services.Test/Dotnet_Base_Backend.Services.Test.csproj
@@ -12,8 +12,17 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Dotnet_Base_Backend.Common\Dotnet_Base_Backend.Common.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.DTO\Dotnet_Base_Backend.DTO.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Models\Dotnet_Base_Backend.Models.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Repositories\Dotnet_Base_Backend.Repositories.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Services\Dotnet_Base_Backend.Services.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dotnet_Base_Backend.Services/BaseService.cs
+++ b/Dotnet_Base_Backend.Services/BaseService.cs
@@ -1,0 +1,69 @@
+﻿using Dotnet_Base_Backend.Common.Errors;
+using Dotnet_Base_Backend.DTO;
+using Dotnet_Base_Backend.Models;
+using Dotnet_Base_Backend.Repositories.Interfaces;
+using Dotnet_Base_Backend.Services.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Services
+{
+    public class BaseService: IBaseService
+    {
+        private readonly IBaseRepository _baseRepository;
+
+        public BaseService(IBaseRepository baseRepository)
+        {
+            _baseRepository = baseRepository;
+        }
+
+        public async Task<List<MessageDTO>> GetMessage()
+        {
+            try
+            {
+                List<MessageDTO> result = new List<MessageDTO>();
+                var messages = await _baseRepository.GetMessage();
+                messages.ForEach(message => result.Add(new MessageDTO() { Message = message }));
+                return result;
+            }
+            catch (Exception ex)
+            {
+                throw new ServicesException(ErrorCode.INTERNAL_SERVER_ERROR, ex);
+            }
+        }
+
+        public async Task<MessageDTO> SetMessage(string message)
+        {
+            try
+            {
+               MessageDTO result = new MessageDTO();
+               var messages = await _baseRepository.SetMessage(message);
+                if(messages.Count > 0)
+                    result.Message = messages[0];
+                return result;
+            }
+            catch (Exception ex)
+            {
+                throw new ServicesException(ErrorCode.INTERNAL_SERVER_ERROR, ex);
+            }
+        }
+
+        public async Task<List<MessageDTO>> SearchMessage(string message)
+        {
+            try
+            {
+                List<MessageDTO> result = new List<MessageDTO>();
+                var messages = await _baseRepository.SearchMessage(message);
+                messages.ForEach(message => result.Add(new MessageDTO() { Message = message }));
+                return result;
+            }
+            catch (Exception ex)
+            {
+                throw new ServicesException(ErrorCode.INTERNAL_SERVER_ERROR, ex);
+            }
+        }
+    }
+}

--- a/Dotnet_Base_Backend.Services/Dotnet_Base_Backend.Services.csproj
+++ b/Dotnet_Base_Backend.Services/Dotnet_Base_Backend.Services.csproj
@@ -7,7 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Interfaces\" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.DTO\Dotnet_Base_Backend.DTO.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Models\Dotnet_Base_Backend.Models.csproj" />
+    <ProjectReference Include="..\Dotnet_Base_Backend.Repositories\Dotnet_Base_Backend.Repositories.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Dotnet_Base_Backend.Services/Interfaces/IBaseService.cs
+++ b/Dotnet_Base_Backend.Services/Interfaces/IBaseService.cs
@@ -1,0 +1,17 @@
+﻿using Dotnet_Base_Backend.DTO;
+using Dotnet_Base_Backend.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dotnet_Base_Backend.Services.Interfaces
+{
+    public interface IBaseService
+    {
+        Task<List<MessageDTO>> GetMessage();
+        Task<MessageDTO> SetMessage(string message);
+        Task<List<MessageDTO>> SearchMessage(string message);
+    }
+}

--- a/Dotnet_Base_Backend.sln
+++ b/Dotnet_Base_Backend.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dotnet_Base_Backend.Reposit
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dotnet_Base_Backend.API.Test", "Dotnet_Base_Backend.API.Test\Dotnet_Base_Backend.API.Test.csproj", "{682CA28D-A69D-4E06-9E24-01F56FAEF180}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dotnet_Base_Backend.Integration.Test", "Dotnet_Base_Backend.Integration.Test\Dotnet_Base_Backend.Integration.Test.csproj", "{D3E4B3BE-39A6-4845-AA13-44C301417350}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -63,6 +65,10 @@ Global
 		{682CA28D-A69D-4E06-9E24-01F56FAEF180}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{682CA28D-A69D-4E06-9E24-01F56FAEF180}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{682CA28D-A69D-4E06-9E24-01F56FAEF180}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3E4B3BE-39A6-4845-AA13-44C301417350}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D3E4B3BE-39A6-4845-AA13-44C301417350}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D3E4B3BE-39A6-4845-AA13-44C301417350}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D3E4B3BE-39A6-4845-AA13-44C301417350}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This pull request introduces an example endpoint to the Dotnet-Base-Backend project that demonstrates how to pass data through the controller, services, and repository layers. It provides functionality for retrieving and modifying text via HTTP requests.

The endpoint serves as a reference implementation for new developers working on the Dotnet-Base-Backend project, illustrating the flow of data and how to structure endpoints in a maintainable and scalable manner.

1. **Controller:**
   - Created a `BaseController` with GET and POST methods.
   
2. **Service:**
   - Added a `BaseService` to handle business logic for retrieving and modifying text.

3. **Repository:**
   - Implemented a `BaseRepository` to simulate data storage and retrieval.

4. **Tests:**
   - Developed unit tests for controller, service, and repository layers.
   - Created integration tests to validate the complete flow.
close #4 